### PR TITLE
create a function to change job status to in progress (status = 1)

### DIFF
--- a/src/utils/Firebase.tsx
+++ b/src/utils/Firebase.tsx
@@ -199,3 +199,20 @@ export async function setUserData(
     throw error
   }
 }
+
+
+// The status field on a Job stores whether the job is open, in progress, or completed.
+// 0 = Open, 1 = In Progress, 2 = Completed
+// Update the status of a job to in progress (status = 1)
+export async function setJobToInProgress(jobID: string) {
+  try {
+    const jobRef = doc(db, 'Jobs', jobID)
+    await updateDoc(jobRef, { status: 1 })
+
+    console.log('Job status updated to in progress')
+    return { message: 'Job status updated to in progress' }
+  } catch (error) {
+    console.error('Error updating job status:', error)
+    throw error
+  }
+}


### PR DESCRIPTION
This is a simple function that just takes the 'status' field on a job at sets it to 1. Some quick notes:

- Job status is set to 0 by default
- A status of 0 means "Open"
- A status of 1 means "In Progress"
- A status of 2 means "Completed"

The status field is intended to help the frontend differentiate between the jobs, and, for example, avoid displaying jobs that are already in progress or completed to users looking for open jobs. 